### PR TITLE
Feature/must send string for bollean

### DIFF
--- a/src/Controllers/SsoController.php
+++ b/src/Controllers/SsoController.php
@@ -65,7 +65,27 @@ class SsoController extends Controller
             ->except(['external_id', 'email'])
             ->reject([$this, 'nullProperty'])
             ->map([$this, 'parseUserValue'])
+            ->map([$this, 'castBooleansToString'])
             ->toArray();
+    }
+
+    /**
+     * Make boolean's into string
+     *
+     * The Discourse SSO API does not accept 0 or 1 for false or true.  You must send
+     * "false" or "true", so convert any boolean property to the string version.
+     *
+     * @param $property
+     *
+     * @return string
+     */
+    public function castBooleansToString($property)
+    {
+        if (! is_bool($property)) {
+            return $property;
+        }
+
+        return ($property) ? 'true' : 'false';
     }
 
     /**

--- a/tests/Controllers/SsoControllerTest.php
+++ b/tests/Controllers/SsoControllerTest.php
@@ -197,8 +197,8 @@ class SsoControllerTest extends TestCase
                                       1,
                                       'me@mydomain.tld',
                                       [
-                                          'false_value'  => false,
-                                          'true_value'   => true,
+                                          'false_value'  => 'false',
+                                          'true_value'   => 'true',
                                           'string_value' => 'string_property',
                                       ],
                                   ]


### PR DESCRIPTION
This is why the user was not coming over as an admin.  We were sending `admin=1`, but it needed to be `admin=true`.  This will convert all booleans to strings.