### PR TITLE
Update dev packages so that Laravel 6 can be pulled in

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "~7.0.1|~8.0",
         "psy/psysh": "^0.9.9",
         "symfony/thanks": "^1.1",
-        "symfony/var-dumper": "^4.2"
+        "symfony/var-dumper": "~3.0|^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "require-dev": {
         "mockery/mockery": "^1",
         "phpunit/phpunit": "~7.0.1|~8.0",
-        "psy/psysh": "^0.5.1",
-        "symfony/thanks": "^1.0",
-        "symfony/var-dumper": "~3.0|^4.2"
+        "psy/psysh": "^0.9.9",
+        "symfony/thanks": "^1.1",
+        "symfony/var-dumper": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controllers/SsoController.php
+++ b/src/Controllers/SsoController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 /**
  * Class SsoController
@@ -132,7 +133,7 @@ class SsoController extends Controller
             $this->buildExtraParameters()
         );
 
-        return redirect(str_finish($this->config->get('url'), '/').'session/sso_login?'.$query);
+        return redirect(Str::finish($this->config->get('url'), '/').'session/sso_login?'.$query);
     }
 
     /**


### PR DESCRIPTION
- Updated dev packages
- Use `Str::finish()` instead of the deprecated `str_finish()` method

Addresses #16 