### PR TITLE
Fix logout listener

### DIFF
--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -72,7 +72,7 @@ class LogoutDiscourseUser implements ShouldQueue
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
         $response = $this->client->get("users/by-external/{$event->user->id}.json", $configs);
         if($response->getStatusCode() === 200){
-            $user = json_decode($res->getBody())->user;
+            $user = json_decode($response->getBody())->user;
             
 
             $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -76,7 +76,7 @@ class LogoutDiscourseUser implements ShouldQueue
             'base_uri' => $this->config_repository->get('services.discourse.url'),
             'headers'  => [
                 'Api-Key'      => $this->config_repository->get('services.discourse.api_key'),
-                'Api-Username' => $user->username,
+                'Api-Username' => $this->config_repository->get('services.discourse.api_user'),
             ],
         ];
 

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -71,7 +71,7 @@ class LogoutDiscourseUser implements ShouldQueue
 
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
         $response = $this->client->get("users/by-external/{$event->user->id}.json", $configs);
-        if($response->getStatusCode() === 200){
+        if ($response->getStatusCode() === 200) {
             $user = json_decode($response->getBody())->user;
             
 

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -62,11 +62,7 @@ class LogoutDiscourseUser implements ShouldQueue
         }
 
         $configs = [
-            'base_uri' => $this->config_repository->get('services.discourse.url'),
-            'headers'  => [
-                'Api-Key'      => $this->config_repository->get('services.discourse.api.key'),
-                'Api-Username' => $this->config_repository->get('services.discourse.api.user'),
-            ],
+            'base_uri' => $this->config_repository->get('services.discourse.url')
         ];
 
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
@@ -74,8 +70,17 @@ class LogoutDiscourseUser implements ShouldQueue
             $this->client->get("users/by-external/{$event->user->id}.json", $configs)
                          ->getBody()
         )->user;
+        
 
-        $response = $this->client->post("admin/users/{$user->id}/log_out");
+        $configs = [
+            'base_uri' => $this->config_repository->get('services.discourse.url'),
+            'headers'  => [
+                'Api-Key'      => $this->config_repository->get('services.discourse.api_key'),
+                'Api-Username' => $user->username,
+            ],
+        ];
+
+        $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);
 
         if ($response->getStatusCode() !== 200) {
             $this->logger->notice(

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -62,7 +62,11 @@ class LogoutDiscourseUser implements ShouldQueue
         }
 
         $configs = [
-            'base_uri' => $this->config_repository->get('services.discourse.url')
+            'base_uri' => $this->config_repository->get('services.discourse.url'),
+            'headers'  => [
+                'Api-Key'      => $this->config_repository->get('services.discourse.api_key'),
+                'Api-Username' => $this->config_repository->get('services.discourse.api_user'),
+            ],
         ];
 
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
@@ -70,15 +74,6 @@ class LogoutDiscourseUser implements ShouldQueue
             $this->client->get("users/by-external/{$event->user->id}.json", $configs)
                          ->getBody()
         )->user;
-        
-
-        $configs = [
-            'base_uri' => $this->config_repository->get('services.discourse.url'),
-            'headers'  => [
-                'Api-Key'      => $this->config_repository->get('services.discourse.api_key'),
-                'Api-Username' => $this->config_repository->get('services.discourse.api_user'),
-            ],
-        ];
 
         $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);
 

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -64,8 +64,8 @@ class LogoutDiscourseUser implements ShouldQueue
         $configs = [
             'base_uri' => $this->config_repository->get('services.discourse.url'),
             'headers'  => [
-                'Api-Key'      => $this->config_repository->get('services.discourse.api_key'),
-                'Api-Username' => $this->config_repository->get('services.discourse.api_user'),
+                'Api-Key'      => $this->config_repository->get('services.discourse.api.key'),
+                'Api-Username' => $this->config_repository->get('services.discourse.api.user'),
             ],
         ];
 

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -70,18 +70,19 @@ class LogoutDiscourseUser implements ShouldQueue
         ];
 
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
-        $user = json_decode(
-            $this->client->get("users/by-external/{$event->user->id}.json", $configs)
-                         ->getBody()
-        )->user;
+        $response = $this->client->get("users/by-external/{$event->user->id}.json", $configs);
+        if($response->getStatusCode() === 200){
+            $user = json_decode($res->getBody())->user;
+            
 
-        $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);
+            $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);
 
-        if ($response->getStatusCode() !== 200) {
-            $this->logger->notice(
-                "When logging out user {$event->user->id} Discourse returned status code {$response->getStatusCode()}:",
-                ['reason' => $response->getReasonPhrase()]
-            );
+            if ($response->getStatusCode() !== 200) {
+                $this->logger->notice(
+                    "When logging out user {$event->user->id} Discourse returned status code {$response->getStatusCode()}:",
+                    ['reason' => $response->getReasonPhrase()]
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This is a fix to get logout work. 
It is necessary to insert in the services.php the api.key key generated in forum admin as "All user key" and the api.user the username of admin user (see this guide https://meta.discourse.org/t/how-to-create-an-api-key-on-the-admin-panel/87383)