### PR TITLE
Laravel 7 & logout fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "ext-json": "*",
         "cviebrock/discourse-php": "^0.9.3",
         "guzzlehttp/guzzle": "^6.4",
-        "illuminate/auth": "~5.5|~6",
-        "illuminate/routing": "~5.5|~6",
-        "illuminate/support": "~5.5|~6"
+        "illuminate/auth": "~5.5|~6|~7",
+        "illuminate/routing": "~5.5|~6|~7",
+        "illuminate/support": "~5.5|~6|~7"
     },
     "require-dev": {
         "mockery/mockery": "^1",

--- a/src/Listeners/LogoutDiscourseUser.php
+++ b/src/Listeners/LogoutDiscourseUser.php
@@ -70,18 +70,19 @@ class LogoutDiscourseUser implements ShouldQueue
         ];
 
         // Get Discourse user to match this one, and send a Logout request to Discourse and get the response
-        $user = json_decode(
-            $this->client->get("users/by-external/{$event->user->id}.json", $configs)
-                         ->getBody()
-        )->user;
+        $response = $this->client->get("users/by-external/{$event->user->id}.json", $configs);
+        if ($response->getStatusCode() === 200) {
+            $user = json_decode($response->getBody())->user;
+            
 
-        $response = $this->client->post("admin/users/{$user->id}/log_out");
+            $response = $this->client->post("admin/users/{$user->id}/log_out", $configs);
 
-        if ($response->getStatusCode() !== 200) {
-            $this->logger->notice(
-                "When logging out user {$event->user->id} Discourse returned status code {$response->getStatusCode()}:",
-                ['reason' => $response->getReasonPhrase()]
-            );
+            if ($response->getStatusCode() !== 200) {
+                $this->logger->notice(
+                    "When logging out user {$event->user->id} Discourse returned status code {$response->getStatusCode()}:",
+                    ['reason' => $response->getReasonPhrase()]
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This is a fix to get logout work and laravel 7 support.
It is necessary to insert in the services.php the api.key key generated in forum admin as "All user key" and the api.user the username of admin user (see this guide https://meta.discourse.org/t/how-to-create-an-api-key-on-the-admin-panel/87383)